### PR TITLE
feat: New GroupPermission collection

### DIFF
--- a/src/api/general-permission/content-types/general-permission/schema.json
+++ b/src/api/general-permission/content-types/general-permission/schema.json
@@ -11,21 +11,9 @@
     "draftAndPublish": true
   },
   "attributes": {
-    "group": {
-      "type": "enumeration",
-      "enum": [
-        "section",
-        "site",
-        "campaign",
-        "employee"
-      ]
-    },
     "label": {
       "type": "string",
       "required": true
-    },
-    "description": {
-      "type": "text"
     },
     "key": {
       "type": "uid",
@@ -37,9 +25,14 @@
       "target": "api::org-role.org-role",
       "mappedBy": "general_permissions"
     },
-    "field_description": {
-      "type": "text",
-      "default": "Group: (section: Vista o módulo de app), (campaign: Acción a realizar en una campaña) (employee: Acción relacionada con información de empleados) (site: Acción relacionada con vistas o data de sites)"
+    "description": {
+      "type": "text"
+    },
+    "permission_group": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::permission-group.permission-group",
+      "inversedBy": "general_permissions"
     }
   }
 }

--- a/src/api/permission-group/content-types/permission-group/schema.json
+++ b/src/api/permission-group/content-types/permission-group/schema.json
@@ -1,0 +1,30 @@
+{
+  "kind": "collectionType",
+  "collectionName": "permission_groups",
+  "info": {
+    "singularName": "permission-group",
+    "pluralName": "permission-groups",
+    "displayName": "PermissionGroup"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "key": {
+      "type": "uid",
+      "required": true
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "text"
+    },
+    "general_permissions": {
+      "type": "relation",
+      "relation": "oneToMany",
+      "target": "api::general-permission.general-permission",
+      "mappedBy": "permission_group"
+    }
+  }
+}

--- a/src/api/permission-group/controllers/permission-group.js
+++ b/src/api/permission-group/controllers/permission-group.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * permission-group controller
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::permission-group.permission-group');

--- a/src/api/permission-group/routes/permission-group.js
+++ b/src/api/permission-group/routes/permission-group.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * permission-group router
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::permission-group.permission-group');

--- a/src/api/permission-group/services/permission-group.js
+++ b/src/api/permission-group/services/permission-group.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * permission-group service
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::permission-group.permission-group');

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -848,11 +848,6 @@ export interface ApiGeneralPermissionGeneralPermission
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
     description: Schema.Attribute.Text;
-    field_description: Schema.Attribute.Text &
-      Schema.Attribute.DefaultTo<'Group: (section: Vista o m\u00F3dulo de app), (campaign: Acci\u00F3n a realizar en una campa\u00F1a) (employee: Acci\u00F3n relacionada con informaci\u00F3n de empleados) (site: Acci\u00F3n relacionada con vistas o data de sites)'>;
-    group: Schema.Attribute.Enumeration<
-      ['section', 'site', 'campaign', 'employee']
-    >;
     key: Schema.Attribute.UID & Schema.Attribute.Required;
     label: Schema.Attribute.String & Schema.Attribute.Required;
     locale: Schema.Attribute.String & Schema.Attribute.Private;
@@ -864,6 +859,10 @@ export interface ApiGeneralPermissionGeneralPermission
     org_roles: Schema.Attribute.Relation<
       'manyToMany',
       'api::org-role.org-role'
+    >;
+    permission_group: Schema.Attribute.Relation<
+      'manyToOne',
+      'api::permission-group.permission-group'
     >;
     publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
@@ -1141,6 +1140,41 @@ export interface ApiOrganizationOrganization
     sites: Schema.Attribute.Relation<'oneToMany', 'api::site.site'>;
     slug: Schema.Attribute.String & Schema.Attribute.Required;
     theme: Schema.Attribute.Relation<'oneToOne', 'api::theme.theme'>;
+    updatedAt: Schema.Attribute.DateTime;
+    updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+  };
+}
+
+export interface ApiPermissionGroupPermissionGroup
+  extends Struct.CollectionTypeSchema {
+  collectionName: 'permission_groups';
+  info: {
+    displayName: 'PermissionGroup';
+    pluralName: 'permission-groups';
+    singularName: 'permission-group';
+  };
+  options: {
+    draftAndPublish: true;
+  };
+  attributes: {
+    createdAt: Schema.Attribute.DateTime;
+    createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
+      Schema.Attribute.Private;
+    description: Schema.Attribute.Text;
+    general_permissions: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::general-permission.general-permission'
+    >;
+    key: Schema.Attribute.UID & Schema.Attribute.Required;
+    locale: Schema.Attribute.String & Schema.Attribute.Private;
+    localizations: Schema.Attribute.Relation<
+      'oneToMany',
+      'api::permission-group.permission-group'
+    > &
+      Schema.Attribute.Private;
+    name: Schema.Attribute.String;
+    publishedAt: Schema.Attribute.DateTime;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
@@ -2740,6 +2774,7 @@ declare module '@strapi/strapi' {
       'api::lab.lab': ApiLabLab;
       'api::org-role.org-role': ApiOrgRoleOrgRole;
       'api::organization.organization': ApiOrganizationOrganization;
+      'api::permission-group.permission-group': ApiPermissionGroupPermissionGroup;
       'api::principal-navbar.principal-navbar': ApiPrincipalNavbarPrincipalNavbar;
       'api::privacy.privacy': ApiPrivacyPrivacy;
       'api::service-flow.service-flow': ApiServiceFlowServiceFlow;


### PR DESCRIPTION
Se creó la colección GroupPermission para agrupar los diferentes tipos de permisos dependiendo el rubro, también facilita el entendimiento al crear nuevos campos y con las descripciones adicionales el UI es más comprensible