### PR TITLE
feat(*): Add certifications component and update schemas

### DIFF
--- a/src/api/about/content-types/about/schema.json
+++ b/src/api/about/content-types/about/schema.json
@@ -78,6 +78,39 @@
       "type": "relation",
       "relation": "oneToMany",
       "target": "api::site.site"
+    },
+    "app_subtitle": {
+      "type": "string"
+    },
+    "release": {
+      "type": "string"
+    },
+    "intellectual_property": {
+      "type": "string"
+    },
+    "owner": {
+      "type": "string"
+    },
+    "address": {
+      "type": "string"
+    },
+    "copyright": {
+      "type": "string"
+    },
+    "certifications": {
+      "type": "component",
+      "repeatable": true,
+      "component": "pwa.certifications"
+    },
+    "health_regulation": {
+      "type": "component",
+      "repeatable": false,
+      "component": "pwa.certifications"
+    },
+    "data_protection": {
+      "type": "component",
+      "repeatable": false,
+      "component": "pwa.certifications"
     }
   }
 }

--- a/src/components/pwa/certifications.json
+++ b/src/components/pwa/certifications.json
@@ -1,0 +1,28 @@
+{
+  "collectionName": "components_pwa_certifications",
+  "info": {
+    "displayName": "Certifications"
+  },
+  "options": {},
+  "attributes": {
+    "badge_img": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "name": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "bold_description": {
+      "type": "string"
+    }
+  }
+}

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -306,6 +306,19 @@ export interface PwaCancellation extends Struct.ComponentSchema {
   };
 }
 
+export interface PwaCertifications extends Struct.ComponentSchema {
+  collectionName: 'components_pwa_certifications';
+  info: {
+    displayName: 'Certifications';
+  };
+  attributes: {
+    badge_img: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    bold_description: Schema.Attribute.String;
+    description: Schema.Attribute.String;
+    name: Schema.Attribute.String;
+  };
+}
+
 export interface PwaChevronMenu extends Struct.ComponentSchema {
   collectionName: 'components_pwa_chevron_menus';
   info: {
@@ -1273,6 +1286,7 @@ declare module '@strapi/strapi' {
       'pwa.box-button': PwaBoxButton;
       'pwa.button': PwaButton;
       'pwa.cancellation': PwaCancellation;
+      'pwa.certifications': PwaCertifications;
       'pwa.chevron-menu': PwaChevronMenu;
       'pwa.clean-button': PwaCleanButton;
       'pwa.data-card': PwaDataCard;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -386,6 +386,7 @@ export interface ApiAboutAbout extends Struct.CollectionTypeSchema {
     };
   };
   attributes: {
+    address: Schema.Attribute.String;
     app_name: Schema.Attribute.String &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -393,9 +394,13 @@ export interface ApiAboutAbout extends Struct.CollectionTypeSchema {
           localized: true;
         };
       }>;
+    app_subtitle: Schema.Attribute.String;
+    certifications: Schema.Attribute.Component<'pwa.certifications', true>;
+    copyright: Schema.Attribute.String;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;
+    data_protection: Schema.Attribute.Component<'pwa.certifications', false>;
     description: Schema.Attribute.Text &
       Schema.Attribute.Required &
       Schema.Attribute.SetPluginOptions<{
@@ -411,6 +416,8 @@ export interface ApiAboutAbout extends Struct.CollectionTypeSchema {
           localized: false;
         };
       }>;
+    health_regulation: Schema.Attribute.Component<'pwa.certifications', false>;
+    intellectual_property: Schema.Attribute.String;
     locale: Schema.Attribute.String;
     localizations: Schema.Attribute.Relation<'oneToMany', 'api::about.about'>;
     logo: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'> &
@@ -420,7 +427,9 @@ export interface ApiAboutAbout extends Struct.CollectionTypeSchema {
           localized: false;
         };
       }>;
+    owner: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
+    release: Schema.Attribute.String;
     sites: Schema.Attribute.Relation<'oneToMany', 'api::site.site'>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &


### PR DESCRIPTION
This PR contains:
- Add new schema `Certifications` 
- Update the `About` section to add new fields for the re-design of the same page