### PR TITLE
feat: add app_name for pwa instalation

### DIFF
--- a/src/api/site/content-types/site/schema.json
+++ b/src/api/site/content-types/site/schema.json
@@ -112,6 +112,11 @@
       "relation": "manyToMany",
       "target": "api::mi-salud-theme.mi-salud-theme",
       "mappedBy": "sites"
+    },
+    "app_name": {
+      "type": "string",
+      "required": true,
+      "default": "Diagnostikare"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1577,6 +1577,9 @@ export interface ApiSiteSite extends Struct.CollectionTypeSchema {
       'api::ai-assistant-theme.ai-assistant-theme'
     >;
     api_slug: Schema.Attribute.String;
+    app_name: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.DefaultTo<'Diagnostikare'>;
     createdAt: Schema.Attribute.DateTime;
     createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Se agregó el campo app_name a la colección sites para mostrar el nombre de la empresa al instalar la pwa